### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/src/com/ifesdjeen/blomstre/BloomFilter.java
+++ b/src/com/ifesdjeen/blomstre/BloomFilter.java
@@ -50,7 +50,7 @@ public class BloomFilter<T> {
 
   // Murmur is faster than an SHA-based approach and provides as-good collision
   // resistance.  The combinatorial generation approach described in
-  // http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+  // https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf
   // does prove to work in actual tests, and is obviously faster
   // than performing further iterations of murmur.
   long[] getHashBuckets(ByteBuffer b,


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author